### PR TITLE
Minor non-breaking changes for customization

### DIFF
--- a/UI/UICheckBoxes.cs
+++ b/UI/UICheckBoxes.cs
@@ -166,11 +166,13 @@ namespace AlgernonCommons.UI
         /// <param name="atlas">Icon atlas.</param>
         /// <param name="checkedSpriteName">Checked sprite name.</param>
         /// <param name="uncheckedSpriteName">Unchecked sprite name.</param>
+        /// <param name="backgroundAtlas">Background atlas.</param>
+        /// <param name="backgroundSprite">Background sprite name.</param>
         /// <param name="width">Toggle width (default 35).</param>
         /// <param name="height">Toggle height (default 35).</param>
         /// <param name="tooltip">Tooltip, if any.</param>
         /// <returns>New UICheckbox.</returns>
-        public static UICheckBox AddIconToggle(UIComponent parent, float xPos, float yPos, string atlas, string checkedSpriteName, string uncheckedSpriteName, float width = 35f, float height = 35f, string tooltip = null)
+        public static UICheckBox AddIconToggle(UIComponent parent, float xPos, float yPos, string atlas, string checkedSpriteName, string uncheckedSpriteName, string backgroundAtlas = "InGame", string backgroundSprite = "IconPolicyBaseRect", float width = 35f, float height = 35f, string tooltip = null)
         {
             // Create checkbox.
             UICheckBox checkBox = parent.AddUIComponent<UICheckBox>();
@@ -183,18 +185,18 @@ namespace AlgernonCommons.UI
 
             // Add background panel.
             UIPanel panel = checkBox.AddUIComponent<UIPanel>();
-            panel.backgroundSprite = "IconPolicyBaseRect";
+            panel.backgroundSprite = backgroundSprite;
             panel.size = checkBox.size;
             panel.relativePosition = Vector2.zero;
 
             // Event handler to toggle background state on check change.
-            checkBox.eventCheckChanged += (c, isChecked) => panel.backgroundSprite = isChecked ? "IconPolicyBaseRect" : "IconPolicyBaseRectDisabled";
+            checkBox.eventCheckChanged += (c, isChecked) => panel.backgroundSprite = isChecked ? $"{backgroundSprite}Focused" : $"{backgroundSprite}Disabled";
 
             // Event handler to toggle background state on hover.
-            checkBox.eventMouseEnter += (c, p) => panel.backgroundSprite = "IconPolicyBaseRectHovered";
+            checkBox.eventMouseEnter += (c, p) => panel.backgroundSprite = $"{backgroundSprite}Hovered";
 
             // Event handler to toggle background state on de-hover.
-            checkBox.eventMouseLeave += (c, p) => panel.backgroundSprite = checkBox.isChecked ? "IconPolicyBaseRect" : "IconPolicyBaseRectDisabled";
+            checkBox.eventMouseLeave += (c, p) => panel.backgroundSprite = checkBox.isChecked ? $"{backgroundSprite}Focused" : $"{backgroundSprite}Disabled";
 
             // Unchecked sprite.
             UISprite sprite = checkBox.AddUIComponent<UISprite>();

--- a/UI/UICheckBoxes.cs
+++ b/UI/UICheckBoxes.cs
@@ -185,18 +185,39 @@ namespace AlgernonCommons.UI
 
             // Add background panel.
             UIPanel panel = checkBox.AddUIComponent<UIPanel>();
+            panel.atlas = UITextures.GetTextureAtlas(backgroundAtlas);
             panel.backgroundSprite = backgroundSprite;
             panel.size = checkBox.size;
             panel.relativePosition = Vector2.zero;
 
             // Event handler to toggle background state on check change.
-            checkBox.eventCheckChanged += (c, isChecked) => panel.backgroundSprite = isChecked ? $"{backgroundSprite}Focused" : $"{backgroundSprite}Disabled";
+            checkBox.eventCheckChanged += (c, isChecked) => panel.backgroundSprite = isChecked ? $"{backgroundSprite}Focused" : backgroundSprite;
 
             // Event handler to toggle background state on hover.
-            checkBox.eventMouseEnter += (c, p) => panel.backgroundSprite = $"{backgroundSprite}Hovered";
+            checkBox.eventMouseEnter += (c, p) =>
+                                        {
+                                            // We don't have to change anything if we're in a disabled state
+                                            if (!checkBox.isEnabled)
+                                                return;
+                                            panel.backgroundSprite = $"{backgroundSprite}Hovered";
+                                        };
 
             // Event handler to toggle background state on de-hover.
-            checkBox.eventMouseLeave += (c, p) => panel.backgroundSprite = checkBox.isChecked ? $"{backgroundSprite}Focused" : $"{backgroundSprite}Disabled";
+            checkBox.eventMouseLeave += (c, p) =>
+                                        {
+                                            // We don't have to change anything if we're in a disabled state
+                                            if (!checkBox.isEnabled)
+                                                return;
+
+                                            panel.backgroundSprite = checkBox.isChecked ? $"{backgroundSprite}Focused" : backgroundSprite;
+                                        };
+
+            // Event handler to toggle background state on isEnabled change.
+            checkBox.eventIsEnabledChanged += (c, p) =>
+                                              {
+                                                  panel.backgroundSprite = !p ? $"{backgroundSprite}Disabled" : backgroundSprite;
+                                                  panel.isEnabled = p;
+                                              };
 
             // Unchecked sprite.
             UISprite sprite = checkBox.AddUIComponent<UISprite>();

--- a/UI/UIListRow.cs
+++ b/UI/UIListRow.cs
@@ -19,7 +19,7 @@ namespace AlgernonCommons.UI
         public const float Margin = 5f;
 
         // UI components.
-        protected readonly UISprite Background;
+        private readonly UISprite _background;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UIListRow"/> class.
@@ -32,16 +32,43 @@ namespace AlgernonCommons.UI
             isInteractive = true;
 
             // Add background panel.
-            Background = AddUIComponent<UISprite>();
-            Background.relativePosition = Vector2.zero;
-            Background.autoSize = false;
-            Background.zOrder = 0;
+            _background = AddUIComponent<UISprite>();
+            _background.relativePosition = Vector2.zero;
+            _background.autoSize = false;
+            _background.zOrder = 0;
         }
 
         /// <summary>
         /// Gets the height for this row.
         /// </summary>
         public virtual float RowHeight => UIList.DefaultRowHeight;
+
+        /// <summary>
+        /// Sprite name to be used for the internal <see cref="UISprite"/> background.
+        /// </summary>
+        public string BackgroundSpriteName
+        {
+            get => _background.spriteName;
+            set => _background.spriteName = value;
+        }
+
+        /// <summary>
+        /// <see cref="Color"/> to be used for the internal <see cref="UISprite"/> background.
+        /// </summary>
+        public Color BackgroundColor
+        {
+            get => _background.color;
+            set => _background.color = value;
+        }
+
+        /// <summary>
+        /// Opacity to be used for the internal <see cref="UISprite"/> background.
+        /// </summary>
+        public float BackgroundOpacity
+        {
+            get => _background.opacity;
+            set => _background.opacity = value;
+        }
 
         /// <summary>
         /// Generates and displays a row.
@@ -55,7 +82,7 @@ namespace AlgernonCommons.UI
         /// </summary>
         public virtual void Select()
         {
-            Background.color = new Color32(255, 255, 255, 255);
+            _background.color = new Color32(255, 255, 255, 255);
         }
 
         /// <summary>
@@ -67,13 +94,13 @@ namespace AlgernonCommons.UI
             if (rowIndex % 2 == 0)
             {
                 // Darker background for even rows.
-                Background.spriteName = null;
+                _background.spriteName = null;
             }
             else
             {
                 // Lighter background for odd rows.
-                Background.spriteName = "UnlockingItemBackground";
-                Background.color = new Color32(0, 0, 0, 128);
+                _background.spriteName = "UnlockingItemBackground";
+                _background.color = new Color32(0, 0, 0, 128);
             }
         }
 
@@ -85,7 +112,7 @@ namespace AlgernonCommons.UI
             base.OnSizeChanged();
 
             // Resize background panel to match current size.
-            Background.size = this.size;
+            _background.size = this.size;
         }
 
         /// <summary>

--- a/UI/UIListRow.cs
+++ b/UI/UIListRow.cs
@@ -19,7 +19,7 @@ namespace AlgernonCommons.UI
         public const float Margin = 5f;
 
         // UI components.
-        private readonly UISprite _background;
+        protected readonly UISprite Background;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="UIListRow"/> class.
@@ -32,10 +32,10 @@ namespace AlgernonCommons.UI
             isInteractive = true;
 
             // Add background panel.
-            _background = AddUIComponent<UISprite>();
-            _background.relativePosition = Vector2.zero;
-            _background.autoSize = false;
-            _background.zOrder = 0;
+            Background = AddUIComponent<UISprite>();
+            Background.relativePosition = Vector2.zero;
+            Background.autoSize = false;
+            Background.zOrder = 0;
         }
 
         /// <summary>
@@ -53,28 +53,27 @@ namespace AlgernonCommons.UI
         /// <summary>
         /// Sets the row display to the selected state (highlighted).
         /// </summary>
-        public void Select()
+        public virtual void Select()
         {
-            _background.spriteName = "ListItemHighlight";
-            _background.color = new Color32(255, 255, 255, 255);
+            Background.color = new Color32(255, 255, 255, 255);
         }
 
         /// <summary>
         /// Sets the row display to the deselected state.
         /// </summary>
         /// <param name="rowIndex">Row index number (for background banding).</param>
-        public void Deselect(int rowIndex)
+        public virtual void Deselect(int rowIndex)
         {
             if (rowIndex % 2 == 0)
             {
                 // Darker background for even rows.
-                _background.spriteName = null;
+                Background.spriteName = null;
             }
             else
             {
                 // Lighter background for odd rows.
-                _background.spriteName = "UnlockingItemBackground";
-                _background.color = new Color32(0, 0, 0, 128);
+                Background.spriteName = "UnlockingItemBackground";
+                Background.color = new Color32(0, 0, 0, 128);
             }
         }
 
@@ -86,7 +85,7 @@ namespace AlgernonCommons.UI
             base.OnSizeChanged();
 
             // Resize background panel to match current size.
-            _background.size = this.size;
+            Background.size = this.size;
         }
 
         /// <summary>


### PR DESCRIPTION
Adding this PR with some minor changes (backward compatible) that I'm using for Parallel Road Tool.

The changes are just two:

1. You can now specify a custom background sprite for the icon checkbox
2. You can now specify change background's properties in a `UIListRow` (used to customize things such as the sprite and the color)

I've added them in a way that they won't require any changes to code that's already using the two classes.